### PR TITLE
Added getEndpointList

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -939,7 +939,7 @@ pub fn getEndpointList(allocator: *std.mem.Allocator, name: []const u8, port: u1
 
         return result;
     }
-    @compileError("std.net.getAddresses unimplemented for this OS");
+    @compileError("unsupported os " ++ @tagName(std.builtin.os.tag) ++ " for getEndpointList!");
 }
 
 const GetAddrInfoError = error{


### PR DESCRIPTION
I initially started adapting all of the `std.net` code for non-libc linux as well but it is a lot, we fall back to using it from std.net for now.  

However testing this without libc on WSL fails with `temporaryNameServerFailure`, not sure if this is a WSL thing or a `std.net` bug (the libc version works).  

Adding `connectToHost` soon.