### PR TITLE
IPv6 support 

### DIFF
--- a/testsuite.zig
+++ b/testsuite.zig
@@ -1,7 +1,19 @@
 const std = @import("std");
 const network = @import("network.zig");
 
-test "addrlist" {
+test "Get endpoint list" {
+    try network.init();
+    defer network.deinit();
+
+    const endpoint_list = try network.getEndpointList(std.heap.page_allocator, "google.com", 80);
+    defer endpoint_list.deinit();
+
+    for (endpoint_list.endpoints) |endpt| {
+        std.debug.warn("{}\n", .{endpt});
+    }
+}
+
+test "Connect to an echo server" {
     try network.init();
     defer network.deinit();
 


### PR DESCRIPTION
Here is a simple test that listens on IPv6 loopback and accepts a single client as a small test.

```zig
const std = @import("std");
const network = @import("network.zig");

test "Listen on loopback ipv6" {
    try network.init();
    defer network.deinit();

    var server = try network.Socket.create(.ipv6, .tcp);
    defer server.close();

    std.debug.warn("Loopback addr: {}\n", .{network.Address.IPv6.loopback});

    try server.bind(.{
        .address = .{ .ipv6 = network.Address.IPv6.loopback },
        .port = 0,
    });

    try server.listen();

    const endpt = try server.getLocalEndPoint();
    std.debug.warn("Listening on {}\n", .{endpt});

    // Make a client!
    const client = try network.Socket.create(.ipv6, .tcp);
    try client.connect(endpt);
    defer client.close();

    const msg = "Hello from the same process";
    try client.outStream().writeAll(msg);

    // Accept on the server
    {
        const accepted = try server.accept();
        defer accepted.close();

        std.debug.warn("Accepted {}\n", .{try accepted.getRemoteEndPoint()});
        
        var buf: [128]u8 = undefined;
        std.debug.warn("Read message: {}\n", .{buf[0..try accepted.inStream().readAll(buf[0..msg.len])]});
    }
}

```