### PR TITLE
Fix SIGPIPE on MacOS

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -6,7 +6,7 @@ comptime {
 }
 
 const is_windows = std.builtin.os.tag == .windows;
-const is_mac = std.builtin.os.tag == .macosx;
+const is_mac = std.builtin.os.tag.isDarwin();
 
 pub fn init() error{InitializationError}!void {
     if (is_windows) {


### PR DESCRIPTION
On BSD you set the signal options on the socket itself, rather than on each message. Unfortunately the bits SO_NOSIGPIPE are not set upstream for macos (they are for BSD), so I defined it within the function itself for now.

This PR fixes compilation error on MacOS and allows the testsuite to be run again. I have not yet tested async yet.
