### PR TITLE
Async and Poll() support for MacOs

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -6,7 +6,7 @@ comptime {
 }
 
 const is_windows = std.builtin.os.tag == .windows;
-const is_mac = std.builtin.os.tag == .macosx;
+const is_mac = std.builtin.os.tag.isDarwin();
 
 pub fn init() error{InitializationError}!void {
     if (is_windows) {


### PR DESCRIPTION
This PR adds async support by setting the socket flags explicitly. This cooperates with the std as it will set the corresponding Darwin flag accordingly (using a shim). 
Poll() works the same on Darwin/BSD as Linux therefore I created an alias to LinuxOsLogic. I don't have a BDS system to test on so didn't add support for that. 
I used the following Gist to test async support. This allows multiple clients to connect and send messages to the TCP server which are printed in stderr: https://gist.github.com/Luukdegram/603a2ea72485680340215d02b344fd72