### PR TITLE
MacOs async and poll() support

### DIFF
--- a/async.zig
+++ b/async.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const network = @import("network.zig");
+
+pub const io_mode = .evented;
+
+pub fn main() anyerror!void {
+    const allocator = std.heap.page_allocator;
+
+    try network.init();
+    defer network.deinit();
+
+    var server = try network.Socket.create(.ipv4, .tcp);
+    defer server.close();
+
+    try server.bind(.{
+        .address = .{ .ipv4 = network.Address.IPv4.any },
+        .port = 2501,
+    });
+
+    try server.listen();
+    std.debug.warn("listening at {}\n", .{try server.getLocalEndPoint()});
+    while (true) {
+        std.debug.print("Waiting for connection\n", .{});
+        const client = try allocator.create(Client);
+        client.* = Client{
+            .conn = try server.accept(),
+            .handle_frame = async client.handle(),
+        };
+    }
+}
+
+const Client = struct {
+    conn: network.Socket,
+    handle_frame: @Frame(Client.handle),
+
+    fn handle(self: *Client) !void {
+        try self.conn.writer().writeAll("server: welcome to the chat server\n");
+
+        while (true) {
+            var buf: [100]u8 = undefined;
+            const amt = try self.conn.receive(&buf);
+            const msg = buf[0..amt];
+            std.debug.print("Client wrote: {}", .{msg});
+        }
+    }
+};


### PR DESCRIPTION
This PR adds async support by setting the socket flags explicitly. This cooperates with the std as it will set the corresponding Darwin flag accordingly (using a shim).
Poll() works the same on Darwin/BSD as Linux therefore I created an alias to LinuxOsLogic. I don't have a BDS system to test on so didn't add support for that.