### PR TITLE
Yield FileDescriptorNotASocket to the user

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -264,7 +264,7 @@ pub const EndPoint = struct {
 /// incoming connections if bound as a TCP server.
 pub const Socket = struct {
     pub const SendError = (std.os.SendError || std.os.SendToError);
-    pub const ReceiveError = std.os.RecvFromError;
+    pub const ReceiveError = std.os.RecvFromError || error{FileDescriptorNotASocket};
 
     pub const Reader = std.io.Reader(Socket, ReceiveError, receive);
     pub const Writer = std.io.Writer(Socket, SendError, send);
@@ -1303,7 +1303,7 @@ const windows = struct {
         flags: u32,
         src_addr: ?*std.os.sockaddr,
         addrlen: ?*std.os.socklen_t,
-    ) std.os.RecvFromError!usize {
+    ) Socket.ReceiveError!usize {
         if (std.io.is_async and std.event.Loop.instance != null) {
             const loop = std.event.Loop.instance.?;
 
@@ -1355,7 +1355,7 @@ const windows = struct {
                     .WSAEFAULT => unreachable,
                     .WSAEINVAL => unreachable,
                     .WSAEISCONN => unreachable,
-                    .WSAENOTSOCK => unreachable,
+                    .WSAENOTSOCK => error.FileDescriptorNotASocket,
                     .WSAESHUTDOWN => unreachable,
                     .WSAEOPNOTSUPP => unreachable,
                     .WSAEWOULDBLOCK => error.WouldBlock,


### PR DESCRIPTION
Meant to address #34. On Windows when dealing with a UDP socket in a thread for example, there is no way to cleanly close the socket or signal it to exit from the other thread while it is stuck in a blocking call to `receive`. Calling `std.os.shutdown` on the socket also doesn't do anything in this case. Because of this, the only solution I can think of is to yield `error.FileDescriptorNotASocket` back to the user and allow them to handle it closing instead of hitting an `unreachable`.