### PR TITLE
Adding UDP multicast example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,13 @@ jobs:
         # if: ${{ matrix.platform != 'windows-latest' }}
         run: |
           zig build async-examples
+
+      - name: Compile and test udp
+        # if: ${{ matrix.platform != 'windows-latest' }}
+        run: |
+          zig build udp-examples
+
+      - name: Compile and test discovery
+        # if: ${{ matrix.platform != 'windows-latest' }}
+        run: |
+          zig build discovery-examples

--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,11 @@ pub fn build(b: *std.build.Builder) !void {
     echo_example.setTarget(target);
     echo_example.addPackage(pkgs.network);
 
+    const udp_example = b.addExecutable("udp", "examples/multicast_udp.zig");
+    udp_example.setBuildMode(mode);
+    udp_example.setTarget(target);
+    udp_example.addPackage(pkgs.network);
+
     const test_step = b.step("test", "Runs the test suite.");
     test_step.dependOn(&test_runner.step);
 
@@ -34,4 +39,7 @@ pub fn build(b: *std.build.Builder) !void {
 
     const async_examples_step = b.step("async-examples", "Builds the examples");
     async_examples_step.dependOn(&b.addInstallArtifact(async_example).step);
+
+    const udp_examples_step = b.step("udp-examples", "Builds multicast udp examples");
+    udp_examples_step.dependOn(&b.addInstallArtifact(udp_example).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,16 @@ pub fn build(b: *std.build.Builder) !void {
     udp_example.setTarget(target);
     udp_example.addPackage(pkgs.network);
 
+    const discovery_client = b.addExecutable("discovery_client", "examples/discovery/client.zig");
+    discovery_client.setBuildMode(mode);
+    discovery_client.setTarget(target);
+    discovery_client.addPackage(pkgs.network);
+
+    const discovery_server = b.addExecutable("discovery_server", "examples/discovery/server.zig");
+    discovery_server.setBuildMode(mode);
+    discovery_server.setTarget(target);
+    discovery_server.addPackage(pkgs.network);
+
     const test_step = b.step("test", "Runs the test suite.");
     test_step.dependOn(&test_runner.step);
 
@@ -40,6 +50,10 @@ pub fn build(b: *std.build.Builder) !void {
     const async_examples_step = b.step("async-examples", "Builds the examples");
     async_examples_step.dependOn(&b.addInstallArtifact(async_example).step);
 
-    const udp_examples_step = b.step("udp-examples", "Builds multicast udp examples");
+    const udp_examples_step = b.step("udp-examples", "Builds UDP examples");
     udp_examples_step.dependOn(&b.addInstallArtifact(udp_example).step);
+
+    const discovery_examples_step = b.step("discovery-examples", "Builds UDP/TCP Server Discovery examples");
+    discovery_examples_step.dependOn(&b.addInstallArtifact(discovery_client).step);
+    discovery_examples_step.dependOn(&b.addInstallArtifact(discovery_server).step);
 }

--- a/examples/discovery/client.zig
+++ b/examples/discovery/client.zig
@@ -1,0 +1,152 @@
+const std = @import("std");
+const network = @import("network");
+
+// Multicast UDP example, using threads + sync IO
+
+// Scanner Thread :
+// Listens on 224.0.0.1:8080 for UDP broadcasts from Game Servers
+// that advertise their address, and add them to the list
+
+// main thread:
+// periodically print the list of known servers
+
+// Server is a container for holding data on servers discovered on the network
+const Server = struct {
+    const Self = @This();
+    address: network.Address,
+    name: []u8,
+
+    pub fn format(value: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = fmt;
+        _ = options;
+        try writer.print("Server: {} : {s}", .{
+            value.address,
+            value.name,
+        });
+    }
+};
+
+// ServerList is a thread safe list of Server structs
+const ServerList = struct {
+    const Self = @This();
+    list: std.ArrayList(Server),
+    mutex: std.Thread.Mutex,
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return Self{
+            .list = std.ArrayList(Server).init(allocator),
+            .mutex = std.Thread.Mutex{},
+        };
+    }
+
+    pub fn deinit(value: Self) void {
+        value.list.deinit();
+    }
+
+    pub fn append(value: *Self, data: Server) !void {
+        value.mutex.lock();
+        defer value.mutex.unlock();
+        for (value.list.items) |item| {
+            if (std.meta.eql(item.address, data.address)) {
+                // is already in the list, dont add it again
+                return;
+            }
+        }
+        std.debug.print(">> Discovered {}\n", .{data});
+        try value.list.append(data);
+    }
+
+    pub fn getServers(value: Self) []Server {
+        return value.list.items;
+    }
+};
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+
+    try network.init();
+    defer network.deinit();
+
+    var server_list = ServerList.init(allocator);
+    defer server_list.deinit();
+
+    // background task to collect servers via UDP broadcasts
+    var server_thread = try std.Thread.spawn(.{ .stack_size = 1024 }, scanServersThread, .{
+        allocator,
+        &server_list,
+    });
+    server_thread.detach();
+
+    // Show the found servers every 5 seconds
+    var last_count: usize = 0;
+    while (true) {
+        server_list.mutex.lock();
+        var servers = server_list.getServers();
+        if (servers.len != last_count) {
+            std.debug.print("\nDiscovered Servers:\n===================\n", .{});
+            for (servers) |s| {
+                std.debug.print("{}\n", .{s});
+            }
+            last_count = servers.len;
+        }
+        server_list.mutex.unlock();
+        std.time.sleep(1 * std.time.ns_per_s);
+    }
+}
+
+// scanServersThread - runs in a thread
+// Listens for broadcast UDP packets to collect server information
+// and add the details to the ServerList passed in
+fn scanServersThread(allocator: std.mem.Allocator, server_list: *ServerList) !void {
+    std.debug.print("Scanning for Servers to connect to ....\n", .{});
+
+    const port_number = 8080;
+
+    // Create a UDP socket
+    var sock = try network.Socket.create(.ipv4, .udp);
+    defer sock.close();
+
+    // Bind to 224.0.0.1:8080, allow port re-use so that multiple instances
+    // of this program can all subscribe to the UDP broadcasts
+    try sock.enablePortReuse(true);
+    const incoming_endpoint = network.EndPoint{
+        .address = network.Address{ .ipv4 = network.Address.IPv4.multicast_all },
+        .port = port_number,
+    };
+    sock.bind(incoming_endpoint) catch |err| {
+        std.debug.print("failed to bind to {}:{}\n", .{ incoming_endpoint, err });
+    };
+
+    // Join the multicast group on 224.0.0.1
+    const all_group = network.Socket.MulticastGroup{
+        .group = network.Address.IPv4.multicast_all,
+        .interface = network.Address.IPv4.any,
+    };
+    sock.joinMulticastGroup(all_group) catch |err| {
+        std.debug.print("Failed to join mcast group {}:{}\n", .{ all_group, err });
+    };
+
+    const buflen: usize = 128;
+    var msg: [buflen]u8 = undefined;
+
+    while (true) {
+        const recv_msg = try sock.receiveFrom(msg[0..buflen]);
+        var last_char = recv_msg.numberOfBytes;
+
+        // dirty hack to trim any trailing CR/LF from the input
+        // could use std.mem.trimRight twice ?
+        if (msg[last_char - 1] == 10) {
+            last_char -= 1;
+        }
+        if (msg[last_char - 1] == 13) {
+            last_char -= 1;
+        }
+
+        var name = msg[0..last_char];
+
+        try server_list.append(Server{
+            .address = recv_msg.sender.address,
+            .name = try allocator.dupe(u8, name),
+        });
+    }
+}

--- a/examples/discovery/server.zig
+++ b/examples/discovery/server.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const network = @import("network");
+
+// Discovery Server
+// Emits a UDP to the multicast address 224.0.0.1 on port 8080
+// with the name of this server
+
+// See examples/discover/client.zig for code that
+// collects these emitted messages
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // get the name of the server
+    var args_iter = try std.process.argsWithAllocator(allocator);
+    const exe_name = args_iter.next() orelse return error.MissingArgument;
+    defer allocator.free(exe_name);
+
+    const server_name = args_iter.next() orelse "Server Name";
+    defer allocator.free(server_name);
+
+    // Create a UDP socket
+    try network.init();
+    defer network.deinit();
+    var sock = try network.Socket.create(.ipv4, .udp);
+    defer sock.close();
+
+    const endpoint = network.EndPoint{
+        .address = network.Address{
+            .ipv4 = network.Address.IPv4.multicast_all,
+        },
+        .port = 8080,
+    };
+
+    // Setup the readloop
+    std.debug.print("Sending UDP messages to multicast address {}\n", .{endpoint});
+    while (true) {
+        _ = try sock.sendTo(endpoint, server_name);
+        std.time.sleep(2 * std.time.ns_per_s);
+    }
+}

--- a/examples/multicast_udp.zig
+++ b/examples/multicast_udp.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const network = @import("network");
+
+// Multicast UDP example
+// listens on 224.0.0.1 (all machines on subnet) on port 9999
+
+// You can run this on any node on your local network,
+// each instance will receive UDPs sent to the multicast address
+
+// You can run multiple instances of this program, all listening
+// for the same UDP broadcast on the same port.
+
+// test this by doing this from any machine on the network
+// echo "this is a test" | nc -u 224.0.0.1 9999
+
+pub fn main() !void {
+    const port_number = 9999;
+
+    try network.init();
+    defer network.deinit();
+
+    // Create a UDP socket
+    var sock = try network.Socket.create(.ipv4, .udp);
+    defer sock.close();
+
+    // Bind to 224.0.0.1:9999, allow port re-use so that multiple instances
+    // of this program can all subscribe to the UDP broadcasts
+    try sock.enablePortReuse(true);
+    const incoming_endpoint = network.EndPoint{
+        .address = network.Address{ .ipv4 = network.Address.IPv4.multicast_all },
+        .port = port_number,
+    };
+    sock.bind(incoming_endpoint) catch |err| {
+        std.debug.print("failed to bind to {}:{}\n", .{ incoming_endpoint, err });
+    };
+
+    // Join the multicast group on 224.0.0.1
+    const all_group = network.Socket.MulticastGroup{
+        .group = network.Address.IPv4.multicast_all,
+        .interface = network.Address.IPv4.any,
+    };
+    sock.joinMulticastGroup(all_group) catch |err| {
+        std.debug.print("Failed to join mcast group {}:{}\n", .{ all_group, err });
+    };
+
+    // Setup the readloop
+    std.debug.print("Waiting for UDP messages from socket {}\n", .{sock.bound_to});
+    const buflen = 4096;
+    var msg: [buflen]u8 = undefined;
+    const r = sock.reader();
+    while (true) {
+        const bytes = try r.read(msg[0..buflen]);
+        std.debug.print(">> {s}\n", .{msg[0..bytes]});
+    }
+}

--- a/examples/multicast_udp.zig
+++ b/examples/multicast_udp.zig
@@ -11,11 +11,9 @@ const network = @import("network");
 // for the same UDP broadcast on the same port.
 
 // test this by doing this from any machine on the network
-// echo "this is a test" | nc -u 224.0.0.1 9999
+// echo "this is a test" | nc -u -w0 224.0.0.1 9999
 
 pub fn main() !void {
-    const port_number = 9999;
-
     try network.init();
     defer network.deinit();
 
@@ -28,7 +26,7 @@ pub fn main() !void {
     try sock.enablePortReuse(true);
     const incoming_endpoint = network.EndPoint{
         .address = network.Address{ .ipv4 = network.Address.IPv4.multicast_all },
-        .port = port_number,
+        .port = 9999,
     };
     sock.bind(incoming_endpoint) catch |err| {
         std.debug.print("failed to bind to {}:{}\n", .{ incoming_endpoint, err });
@@ -44,7 +42,7 @@ pub fn main() !void {
     };
 
     // Setup the readloop
-    std.debug.print("Waiting for UDP messages from socket {}\n", .{sock.bound_to});
+    std.debug.print("Waiting for UDP messages from socket {}\n", .{sock.getLocalEndPoint()});
     const buflen = 4096;
     var msg: [buflen]u8 = undefined;
     const r = sock.reader();

--- a/testsuite.zig
+++ b/testsuite.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const network = @import("network");
+const expect = std.testing.expect;
 
 test "Get endpoint list" {
     try network.init();


### PR DESCRIPTION
- Add simple UDP listener
- On each socket, store 'connected_to' and 'bound_to' endpoints