### PR TITLE
Fix "WSAEOPNOTSUPP" error in Socket.receiveFrom

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -416,7 +416,7 @@ pub const Socket = struct {
         var size: std.os.socklen_t = @sizeOf(std.os.sockaddr.in6);
 
         var addr_ptr = @ptrCast(*std.os.sockaddr, &addr);
-        const len = try recvfrom_fn(self.internal, data, flags | if (windows) 0 else 4, addr_ptr, &size);
+        const len = try recvfrom_fn(self.internal, data, flags | 4, addr_ptr, &size);
 
         return ReceiveFrom{
             .numberOfBytes = len,

--- a/network.zig
+++ b/network.zig
@@ -416,7 +416,7 @@ pub const Socket = struct {
         var size: std.os.socklen_t = @sizeOf(std.os.sockaddr.in6);
 
         var addr_ptr = @ptrCast(*std.os.sockaddr, &addr);
-        const len = try recvfrom_fn(self.internal, data, flags | 4, addr_ptr, &size);
+        const len = try recvfrom_fn(self.internal, data, flags | if (is_windows) 0 else 4, addr_ptr, &size);
 
         return ReceiveFrom{
             .numberOfBytes = len,

--- a/network.zig
+++ b/network.zig
@@ -416,7 +416,7 @@ pub const Socket = struct {
         var size: std.os.socklen_t = @sizeOf(std.os.sockaddr.in6);
 
         var addr_ptr = @ptrCast(*std.os.sockaddr, &addr);
-        const len = try recvfrom_fn(self.internal, data, flags | 4, addr_ptr, &size);
+        const len = try recvfrom_fn(self.internal, data, flags | if (windows) 0 else 4, addr_ptr, &size);
 
         return ReceiveFrom{
             .numberOfBytes = len,


### PR DESCRIPTION
Hi!

I was trying zig-network on Windows and found that when I called `receiveFrom` over UDP, I always got a `WSAEOPNOTSUPPP` error. The reason for this is that the `lpFlags` argument to `WSARecvFrom` and `recvfrom` is incorrect. I fixed it so that it works fine on Windows. 

 [WSARecvFrom](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom)
 [recvfrom](https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom)