### PR TITLE
Add socket.peek()

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -428,7 +428,7 @@ pub const Socket = struct {
     /// Will not change the stream state.
     pub fn peek(self: Self, data: []u8) ReceiveError!usize {
         const recvfrom_fn = if (is_windows) windows.recvfrom else std.os.recvfrom;
-        const flags = if (is_windows or is_bsd) 0 else std.os.linux.MSG.PEEK;
+        const flags = if (is_windows) 0x2 else std.os.linux.MSG.PEEK;
         return try recvfrom_fn(self.internal, data, flags, null, null);   
     }
 

--- a/network.zig
+++ b/network.zig
@@ -423,6 +423,15 @@ pub const Socket = struct {
         const flags = if (is_windows or is_bsd) 0 else std.os.linux.MSG.NOSIGNAL;
         return try send_fn(self.internal, data, flags);
     }
+    
+    /// Non-Blockingly peeks at data from the connected peer.
+    /// Will not change the stream state.
+    pub fn peek(self: Self, data: []u8) ReceiveError!usize {
+        const recvfrom_fn = if (is_windows) windows.recvfrom else std.os.recvfrom;
+        const flags = if (is_windows or is_bsd) 0 else std.os.linux.MSG.PEEK;
+        return try recvfrom_fn(self.internal, data, flags, null, null);   
+    }
+
 
     /// Blockingly receives some data from the connected peer.
     /// Will read all available data from the TCP stream or


### PR DESCRIPTION
Adds a "peek" function using MSG_PEEK to gather information on the data held in the stream state. Can be used to check things like Packet IDs or VarInt lengths and then determine a proper buffer reallocation for the size.