### PR TITLE
Add setBroadcast function to enable or disable SO_BROADCAST socket option for UDPv4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,8 @@ jobs:
         # if: ${{ matrix.platform != 'windows-latest' }}
         run: |
           zig build discovery-examples
+
+      - name: Compile and test udp
+        run: |
+          zig build udp-broadcast
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           zig build discovery-examples
 
-      - name: Compile and test udp
+      - name: Compile and test udp broadcast
         run: |
           zig build udp-broadcast
 

--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *std.build.Builder) !void {
     async_example.setBuildMode(mode);
     async_example.setTarget(target);
     async_example.addPackage(pkgs.network);
-    async_example.use_stage1 = true;
+    // async_example.use_stage1 = true;
 
     const echo_example = b.addExecutable("echo", "examples/echo.zig");
     echo_example.setBuildMode(mode);
@@ -31,6 +31,11 @@ pub fn build(b: *std.build.Builder) !void {
     udp_example.setBuildMode(mode);
     udp_example.setTarget(target);
     udp_example.addPackage(pkgs.network);
+
+    const udp_broadcast = b.addExecutable("broadcast", "examples/udp_broadcast.zig");
+    udp_broadcast.setBuildMode(mode);
+    udp_broadcast.setTarget(target);
+    udp_broadcast.addPackage(pkgs.network);
 
     const discovery_client = b.addExecutable("discovery_client", "examples/discovery/client.zig");
     discovery_client.setBuildMode(mode);
@@ -53,6 +58,9 @@ pub fn build(b: *std.build.Builder) !void {
 
     const udp_examples_step = b.step("udp-examples", "Builds UDP examples");
     udp_examples_step.dependOn(&b.addInstallArtifact(udp_example).step);
+
+    const udp_broadcast_step = b.step("udp-broadcast", "Builds UDP broadcast example");
+    udp_broadcast_step.dependOn(&b.addInstallArtifact(udp_broadcast).step);
 
     const discovery_examples_step = b.step("discovery-examples", "Builds UDP/TCP Server Discovery examples");
     discovery_examples_step.dependOn(&b.addInstallArtifact(discovery_client).step);

--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *std.build.Builder) !void {
     async_example.setBuildMode(mode);
     async_example.setTarget(target);
     async_example.addPackage(pkgs.network);
-    // async_example.use_stage1 = true;
+    async_example.use_stage1 = true;
 
     const echo_example = b.addExecutable("echo", "examples/echo.zig");
     echo_example.setBuildMode(mode);

--- a/examples/udp_broadcast.zig
+++ b/examples/udp_broadcast.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const network = @import("network");
+
+// Broadcast UDP example
+// Broadcasts a 64 byte UDP packet to port 60000 and waits for a reply.
+
+// Test this by listening for a UDP broadcast on any machine on the same network segment:
+// nc -lu 60000 | xxd
+
+const BUFFER_SIZE = 1024;
+
+pub fn main() !void {
+    std.debug.print("   UDP broadcast example\n\n", .{});
+    try network.init();
+    defer network.deinit();
+
+    // Create a UDP socket with SO_BROADCAST enabled
+    var sock = try network.Socket.create(.ipv4, .udp);
+    defer sock.close();
+
+    try sock.setBroadcast(true);
+
+    // Bind to 0.0.0.0:0
+    const bindAddr = network.EndPoint{
+        .address = network.Address{ .ipv4 = network.Address.IPv4.any },
+        .port = 0,
+    };
+
+    const destAddr = network.EndPoint{
+        .address = network.Address{ .ipv4 = network.Address.IPv4.broadcast },
+        .port = 60000,
+    };
+
+    try sock.bind(bindAddr);
+
+    // Send broadcast packet
+    const packet = [64]u8{
+        0x17, 0x94, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+
+    const N = try sock.sendTo(destAddr, &packet);
+
+    std.debug.print("   sent {any} bytes\n", .{N});
+    dump(packet);
+}
+
+fn dump(packet: [64]u8) void {
+    const offsets = [_]usize{ 0, 16, 32, 48 };
+    for (offsets) |ix| {
+        const f = "{x:0<2} {x:0<2} {x:0<2} {x:0<2} {x:0<2} {x:0<2} {x:0<2} {x:0<2}";
+        const u = packet[ix .. ix + 8];
+        const v = packet[ix + 8 .. ix + 16];
+        std.debug.print("   ", .{});
+        std.debug.print(f, .{ u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7] });
+        std.debug.print("  ", .{});
+        std.debug.print(f, .{ v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7] });
+        std.debug.print("\n", .{});
+    }
+
+    std.debug.print("\n", .{});
+}

--- a/network.zig
+++ b/network.zig
@@ -397,6 +397,18 @@ pub const Socket = struct {
         }
     }
 
+    /// Sets the SO_BROADCAST socket option to enable/disable UDP broadcast. Only supported for IPv4.
+    pub fn setBroadcast(self: *Self, enable: bool) !void {
+        std.debug.assert(self.family == .ipv4);
+
+        const val: u32 = if (enable) 1 else 0;
+        if (is_windows) {
+            try windows.setsockopt(self.internal, std.os.SOL.SOCKET, std.os.SO.BROADCAST, std.mem.asBytes(&val));
+        } else {
+            try std.os.setsockopt(self.internal, std.os.SOL.SOCKET, std.os.SO.BROADCAST, std.mem.asBytes(&val));
+        }
+    }
+
     /// Connects the UDP or TCP socket to a remote server.
     /// The `target` address type must fit the address type of the socket.
     pub fn connect(self: *Self, target: EndPoint) !void {


### PR DESCRIPTION
1. Adds the `setBroadcast` function to `network.zig` to enable or disable the `SO_BROADCAST` socket option for UDPv4
2. Adds a very basic example to demonstrate usage of _setBroadcast_
3. Adds example to _build.zig_ and github workflow

Ref. [SO_BROADCAST setsockopt for UDP socket](https://github.com/MasterQ32/zig-network/issues/52)