### PR TITLE
Update to latest master `Endian` enum changes

### DIFF
--- a/network.zig
+++ b/network.zig
@@ -160,8 +160,8 @@ pub const Address = union(AddressFamily) {
             }
             const big_endian_parts: *align(1) const [8]u16 = @ptrCast(&self.value);
             const native_endian_parts = switch (builtin.target.cpu.arch.endian()) {
-                .Big => big_endian_parts.*,
-                .Little => blk: {
+                .big => big_endian_parts.*,
+                .little => blk: {
                     var buf: [8]u16 = undefined;
                     for (big_endian_parts, 0..) |part, i| {
                         buf[i] = std.mem.bigToNative(u16, part);

--- a/network.zig
+++ b/network.zig
@@ -104,14 +104,14 @@ pub const Address = union(AddressFamily) {
                 ip.value[0] = try std.fmt.parseInt(u8, d0, 10);
                 ip.value[1] = try std.fmt.parseInt(u8, d1.?, 10);
                 const int = try std.fmt.parseInt(u16, d2.?, 10);
-                std.mem.writeIntBig(u16, ip.value[2..4], int);
+                std.mem.writeInt(u16, ip.value[2..4], int, .big);
             } else if (d1 != null) {
                 ip.value[0] = try std.fmt.parseInt(u8, d0, 10);
                 const int = try std.fmt.parseInt(u24, d1.?, 10);
-                std.mem.writeIntBig(u24, ip.value[1..4], int);
+                std.mem.writeInt(u24, ip.value[1..4], int, .big);
             } else {
                 const int = try std.fmt.parseInt(u32, d0, 10);
-                std.mem.writeIntBig(u32, &ip.value, int);
+                std.mem.writeInt(u32, &ip.value, int, .big);
             }
             return ip;
         }


### PR DESCRIPTION
Master branch standard library currently uses `big` and `little` fields for the `Endian` enum, changed from the previous `Big` and `Little` fields. Additionally, the `writeIntBig`/`writeIntLittle` functions have been removed and now the `writeInt` function must be used instead. 