### PR TITLE
Add `build.zig.zon` for package hash

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "network",
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "network.zig",
+        "testsuite.zig",
+    },
+}


### PR DESCRIPTION
Adding a `build.zig.zon` here allows specifying paths to consider for the package hash. Projects depending on `zig-network` through the Zig package manager will be able to recalculate their hash less frequently when tracking `master`, to only changes that impact:

1. The build system
2. Packaging
3. The actual source
4. Testing
5. License 

Edit: wasn't sure what to put for the version so left it at 0.1.0.