### PR TITLE
fix: free resources in async server example

### DIFF
--- a/examples/async.zig
+++ b/examples/async.zig
@@ -24,16 +24,22 @@ pub fn main() !void {
         const client = try allocator.create(Client);
         client.* = Client{
             .conn = try server.accept(),
-            .handle_frame = async client.handle(),
+            .allocator = allocator,
+            .handle_frame = undefined
         };
+        client.handle_frame = async client.handle();
     }
 }
 
 const Client = struct {
+    allocator: std.mem.Allocator,
     conn: network.Socket,
     handle_frame: @Frame(Client.handle),
 
     fn handle(self: *Client) !void {
+        defer self.conn.close();
+        defer self.allocator.destroy(self);
+
         try self.conn.writer().writeAll("server: welcome to the chat server\n");
 
         while (true) {


### PR DESCRIPTION
I have been playing around with this library to learn zig, and I think I found an issue in the async example where clients are not being cleaned up correctly. I believe the client connection needs to be closed and the client struct needs to be freed when the loop breaks and `handle` returns (i.e. client is disconnected)

I am new to zig so I could be way off base here, but let me know if these changes make sense. Since this is just™️ an example, I figured it would be a pretty low stakes way to test my understanding and contribute.